### PR TITLE
Fix a warning in Bound class

### DIFF
--- a/libchart/Libchart/View/Axis/Bound.php
+++ b/libchart/Libchart/View/Axis/Bound.php
@@ -1,6 +1,6 @@
 <?php
     /* Libchart - PHP chart library
-     * Copyright (C) 2005-2011 Jean-Marc Trémeaux (jm.tremeaux at gmail.com)
+     * Copyright (C) 2005-2011 Jean-Marc TrÃ©meaux (jm.tremeaux at gmail.com)
      * 
      * This program is free software: you can redistribute it and/or modify
      * it under the terms of the GNU General Public License as published by
@@ -24,7 +24,7 @@
      * The bounds are automatically calculated from a XYDataSet or XYSeriesDataSet.
      * Default (calculated) bounds can be overriden using the setLowerBound() and setUpperBound() methods.
      *
-     * @author Jean-Marc Trémeaux (jm.tremeaux at gmail.com)
+     * @author Jean-Marc TrÃ©meaux (jm.tremeaux at gmail.com)
      * Created on 25 july 2007
      */
      class Bound {
@@ -70,7 +70,7 @@
                 $serieList = $dataSet->getSerieList();
                 if (count($serieList) > 0) {
                     $serie = current($serieList);
-                    $dataSetEmpty = count($serie) == 0;
+                    $dataSetEmpty = empty($serie) || count($serie) == 0;
                 }
             } else {
                 die("Error: unknown dataset type");


### PR DESCRIPTION
PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /libchart/Libchart/View/Axis/Bound.php on line 74